### PR TITLE
CMSEditLink() now reflects the nested path of an element.

### DIFF
--- a/_config/elemental.yml
+++ b/_config/elemental.yml
@@ -1,6 +1,6 @@
 ---
 name: elemental-list
 ---
-DNADesign/Elemental/Models/BaseElement:
+DNADesign\Elemental\Models\BaseElement:
   extensions:
-    - DNADesign/ElementalList/Extensions/BaseElementExtension
+    - DNADesign\ElementalList\Extension\BaseElementCMSEditLinkExtension

--- a/src/Extension/BaseElementCMSEditLinkExtension.php
+++ b/src/Extension/BaseElementCMSEditLinkExtension.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace DNADesign\ElementalList\Extension;
+
+use DNADesign\Elemental\Models\BaseElement;
+use DNADesign\ElementalList\Model\ElementList;
+use SilverStripe\CMS\Controllers\CMSPageEditController;
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Extension;
+
+/**
+ * Class BaseElementCMSEditLinkExtension
+ *
+ * BaseElement can be nested, CMSEditLink() needs to be updated to reflect that
+ *
+ * @property BaseElementCMSEditLinkExtension|$this $owner
+ * @package DNADesign\ElementalList\Extension
+ */
+class BaseElementCMSEditLinkExtension extends Extension
+{
+    /**
+     * @param string $link
+     */
+    public function updateCMSEditLink(&$link)
+    {
+        /** @var $owner BaseElement */
+        $owner = $this->owner;
+
+        $relationName = $owner->getAreaRelationName();
+        $page = $owner->getPage(true);
+
+        if (!$page) {
+            return;
+        }
+
+        if ($page instanceof ElementList) {
+            // nested bock - we need to get edit link of parent block
+            $link = Controller::join_links(
+                $page->CMSEditLink(),
+                'ItemEditForm/field/' . $page->getOwnedAreaRelationName() . '/item/',
+                $owner->ID
+            );
+
+            // remove edit link from parent CMS link
+            $link = preg_replace('/\/item\/([\d]+)\/edit/', '/item/$1', $link);
+        } else {
+            // block is directly under a non-block object - we have reached the top of nesting chain
+            $link = Controller::join_links(
+                singleton(CMSPageEditController::class)->Link('EditForm'),
+                $page->ID,
+                'field/' . $relationName . '/item/',
+                $owner->ID
+            );
+        }
+
+        $link = Controller::join_links(
+            $link,
+            'edit'
+        );
+    }
+}

--- a/src/Model/ElementList.php
+++ b/src/Model/ElementList.php
@@ -52,4 +52,22 @@ class ElementList extends BaseElement
 
         return DBField::create_field('HTMLText', $summary . ' <span class="el-meta">Contains ' . $count . ' ' . $suffix . '</span>');
     }
+
+    /**
+     * Retrieve a elemental area relation name which this element owns
+     *
+     * @return string
+     */
+    public function getOwnedAreaRelationName()
+    {
+        $has_one = $this->config()->get('has_one');
+
+        foreach ($has_one as $relationName => $relationClass) {
+            if ($relationClass === ElementalArea::class && $relationName !== 'Parent') {
+                return $relationName;
+            }
+        }
+
+        return 'Elements';
+    }
 }


### PR DESCRIPTION
* `CMSEditLink()` now includes all necessary segments
* removed a broken extension reference to non-existing extension in the config
* requires https://github.com/dnadesign/silverstripe-elemental/pull/170