### PR TITLE
UPDATE: Required elemental version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "dnadesign/silverstripe-elemental": "2.x-dev",
+        "dnadesign/silverstripe-elemental": "^2",
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Elemental is now stable. Holding to the tag version 2 and above, rather than the 2 branch.