### PR TITLE
Handle duplication of pages with elemental-list properly

### DIFF
--- a/src/Model/ElementList.php
+++ b/src/Model/ElementList.php
@@ -26,6 +26,10 @@ class ElementList extends BaseElement
         'Elements'
     ];
 
+    private static $cascade_duplicates = [
+        'Elements'
+    ];
+
     private static $extensions = [
         ElementalAreasExtension::class
     ];
@@ -35,7 +39,7 @@ class ElementList extends BaseElement
     private static $title = 'Group';
 
     private static $description = 'Orderable list of elements';
-    
+
     private static $singular_name = 'list';
 
     private static $plural_name = 'lists';


### PR DESCRIPTION
Evans Hunt (Digital Agency in Calgary, Canada) found that a client was trying to duplicate pages with elemental. It was mostly working after changes that were made to elemental with $cascade-duplicates but any blocks that used elemental-list were not being copied. Instead they were still pointing to the original elemental-list. This fixes that problem.