### PR TITLE
Update elemental version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "dnadesign/silverstripe-elemental": "^2",
+        "dnadesign/silverstripe-elemental": "^3",
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Updating elemental version as was restricting me from using SS 4.2 and switching to using the new file and banner block modules over the now deprecated elemental blocks module.